### PR TITLE
TM JS: Unify import syntax for TurboModuleRegistry

### DIFF
--- a/Libraries/TurboModule/samples/NativeSampleTurboModule.js
+++ b/Libraries/TurboModule/samples/NativeSampleTurboModule.js
@@ -11,7 +11,7 @@
 'use strict';
 
 import type {TurboModule} from 'RCTExport';
-import {getEnforcing} from 'TurboModuleRegistry';
+import * as TurboModuleRegistry from 'TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
   // Exported methods.
@@ -31,4 +31,4 @@ export interface Spec extends TurboModule {
   +getValueWithPromise: (error: boolean) => Promise<string>;
 }
 
-export default getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');


### PR DESCRIPTION
Summary:
For now, we use:

```
import * as TurboModuleRegistry from 'TurboModuleRegistry';

...

TurboModuleRegistry.getEnforcing<Spec>('Foo');
```

Reviewed By: RSNara

Differential Revision: D15020752

fbshipit-source-id: c4e8efaeb978e8f36e5ada998070923c3ed26d21

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
